### PR TITLE
Auto init traits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,13 @@
       "ChrisHalbert\\LaravelNomadic\\": "src"
     }
   },
+  "autoload-dev": {
+    "files": [
+      "tests/files/2018_04_04_000000_StandardMigration.php",
+      "tests/files/2018_04_04_000000_NomadicMockMigration.php",
+      "tests/files/2018_04_04_000000_NomadicMigrationWithPrintable.php"
+    ]
+  },
   "minimum-stability": "dev",
   "prefer-stable" : true
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   "require": {
     "php": "5.* || 7.*",
     "illuminate/database": "5.*",
-    "illuminate/filesystem": "5.*"
+    "illuminate/filesystem": "5.*",
+    "nesbot/carbon": "^1.32"
   },
   "require-dev": {
     "phing/phing": "2.*",

--- a/src/Hooks/NomadicMigrationHookInterface.php
+++ b/src/Hooks/NomadicMigrationHookInterface.php
@@ -2,6 +2,8 @@
 
 namespace ChrisHalbert\LaravelNomadic\Hooks;
 
+use ChrisHalbert\LaravelNomadic\NomadicMigration;
+
 /**
  * Interface NomadicBaseHookInterface
  * @package ChrisHalbert\LaravelNomadic\Hooks
@@ -10,13 +12,8 @@ interface NomadicMigrationHookInterface extends NomadicBaseHookInterface
 {
     /**
      * Executes a function with parameters the create receives.
-     * @param string  $name      The name of the migration.
-     * @param string  $path      The path.
-     * @param string  $table     The name of the table.
-     * @param boolean $create    Whether to use create stub.
-     * @param string  $className The generated name of hte class.
-     * @param string  $filePath  The full path to the file.
+     * @param NomadicMigration $migration A migration.
      * @return string
      */
-    public function execute($name = '', $path = '', $table = null, $create = false, $className = '', $filePath = '');
+    public function execute(NomadicMigration $migration = null);
 }

--- a/src/Hooks/PrintRan.php
+++ b/src/Hooks/PrintRan.php
@@ -3,7 +3,7 @@
 namespace ChrisHalbert\LaravelNomadic\Hooks;
 
 use ChrisHalbert\LaravelNomadic\NomadicMigration;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 
 /**
  * Class PrintRunning

--- a/src/Hooks/PrintRan.php
+++ b/src/Hooks/PrintRan.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ChrisHalbert\LaravelNomadic\Hooks;
+
+use ChrisHalbert\LaravelNomadic\NomadicMigration;
+use Illuminate\Support\Carbon;
+
+/**
+ * Class PrintRunning
+ * @package ChrisHalbert\LaravelNomadic\Hooks
+ */
+class PrintRan implements NomadicMigrationHookInterface
+{
+    /**
+     * Prints the migration running.
+     * @param NomadicMigration $migration The migration.
+     * @return void
+     */
+    public function execute(NomadicMigration $migration = null)
+    {
+        $migrationFileName = $migration ? $migration->getFileName() : 'Migration';
+        echo $migrationFileName . ' finished at ' . Carbon::now()->toDateTimeString();
+    }
+}

--- a/src/Hooks/PrintRunning.php
+++ b/src/Hooks/PrintRunning.php
@@ -3,7 +3,7 @@
 namespace ChrisHalbert\LaravelNomadic\Hooks;
 
 use ChrisHalbert\LaravelNomadic\NomadicMigration;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 
 /**
  * Class PrintRunning

--- a/src/Hooks/PrintRunning.php
+++ b/src/Hooks/PrintRunning.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ChrisHalbert\LaravelNomadic\Hooks;
+
+use ChrisHalbert\LaravelNomadic\NomadicMigration;
+use Illuminate\Support\Carbon;
+
+/**
+ * Class PrintRunning
+ * @package ChrisHalbert\LaravelNomadic\Hooks
+ */
+class PrintRunning implements NomadicMigrationHookInterface
+{
+    /**
+     * Prints the migration running.
+     * @param NomadicMigration $migration The migration.
+     * @return void
+     */
+    public function execute(NomadicMigration $migration = null)
+    {
+        $migrationFileName = $migration ? $migration->getFileName() : 'Migration';
+        echo $migrationFileName . ' started at ' . Carbon::now()->toDateTimeString();
+    }
+}

--- a/src/Traits/Printable.php
+++ b/src/Traits/Printable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ChrisHalbert\LaravelNomadic\Traits;
+
+use ChrisHalbert\LaravelNomadic\Hooks\PrintRan;
+use ChrisHalbert\LaravelNomadic\Hooks\PrintRunning;
+use ChrisHalbert\LaravelNomadic\NomadicMigration;
+
+trait Printable
+{
+    /**
+     * Initializes printable.
+     * @return void
+     */
+    public function initPrintable()
+    {
+        parent::addHook(NomadicMigration::PRE_MIGRATE, new PrintRunning());
+        parent::addHook(NomadicMigration::POST_MIGRATE, new PrintRan());
+        parent::addHook(NomadicMigration::PRE_ROLLBACK, new PrintRunning());
+        parent::addHook(NomadicMigration::POST_MIGRATE, new PrintRan());
+    }
+}

--- a/tests/files/2018_04_04_000000_NomadicMigrationWithPrintable.php
+++ b/tests/files/2018_04_04_000000_NomadicMigrationWithPrintable.php
@@ -1,0 +1,9 @@
+<?php
+
+use ChrisHalbert\LaravelNomadic\Traits\Printable;
+use ChrisHalbert\LaravelNomadic\NomadicMigration;
+
+class NomadicMigrationWithPrintable extends NomadicMigration
+{
+    use Printable;
+}


### PR DESCRIPTION
Traits can now contain hooks that are autoloaded into your migration before it runs.

To have `trait SomeTrait` initialize data or add hooks, you would implement `SomeTrait::initSomeTrait`